### PR TITLE
feat: Add Dashboard component and statistics pages

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,20 @@
 import type { Metadata } from "next";
+import { Inter, Roboto } from "next/font/google";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Loader } from "@/components/ui/Loader";
+
+const roboto = Roboto({
+  subsets: ["latin"],
+  variable: "--font-roboto",
+  weight: ["400", "700"],
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  weight: ["400", "600", "700"],
+});
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${roboto.variable} ${inter.variable} ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Loader />
         {children}

--- a/frontend/src/app/statistics/charts/page.tsx
+++ b/frontend/src/app/statistics/charts/page.tsx
@@ -1,0 +1,24 @@
+import { Dashboard } from "@/components/ui/dashboard/Dashboard";
+
+const Charts: React.FC = () => {
+  const items = [
+    {
+      value: "Resumen de productividad",
+      href: "/statistics/summary",
+      selected: false,
+    },
+    {
+      value: "Gráficos y visualizaciones",
+      href: "/statistics/charts",
+      selected: true,
+    },
+    { value: "Exportar datos", href: "/statistics/export", selected: false },
+  ];
+  return (
+    <Dashboard title="Estadísticas" items={items}>
+      <h1>Gráficos y visualizaciones</h1>
+    </Dashboard>
+  );
+};
+
+export default Charts;

--- a/frontend/src/app/statistics/export/page.tsx
+++ b/frontend/src/app/statistics/export/page.tsx
@@ -1,0 +1,25 @@
+import { Dashboard } from "@/components/ui/dashboard/Dashboard";
+
+const Export: React.FC = () => {
+  const items = [
+    {
+      value: "Resumen de productividad",
+      href: "/statistics/summary",
+      selected: false,
+    },
+    {
+      value: "Gráficos y visualizaciones",
+      href: "/statistics/charts",
+      selected: false,
+    },
+    { value: "Exportar datos", href: "/statistics/export", selected: true },
+  ];
+
+  return (
+    <Dashboard title="Estadísticas" items={items}>
+      <h1>Exportar Datos</h1>
+    </Dashboard>
+  );
+};
+
+export default Export;

--- a/frontend/src/app/statistics/page.tsx
+++ b/frontend/src/app/statistics/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Dashboard } from "@/components/ui/dashboard/Dashboard";
+
+export default function StatisticsPage() {
+  const items = [
+    {
+      value: "Resumen de productividad",
+      href: "/statistics/summary",
+      selected: false,
+    },
+    {
+      value: "Gráficos y visualizaciones",
+      href: "/statistics/charts",
+      selected: false,
+    },
+    { value: "Exportar datos", href: "/statistics/export", selected: false },
+  ];
+
+  return (
+    <Dashboard title="Estadísticas" items={items}>
+      <h1>Hola</h1>
+    </Dashboard>
+  );
+}

--- a/frontend/src/app/statistics/summary/page.tsx
+++ b/frontend/src/app/statistics/summary/page.tsx
@@ -1,0 +1,25 @@
+import { Dashboard } from "@/components/ui/dashboard/Dashboard";
+
+const Summary: React.FC = () => {
+  const items = [
+    {
+      value: "Resumen de productividad",
+      href: "/statistics/summary",
+      selected: true,
+    },
+    {
+      value: "Gráficos y visualizaciones",
+      href: "/statistics/charts",
+      selected: false,
+    },
+    { value: "Exportar datos", href: "/statistics/export", selected: false },
+  ];
+
+  return (
+    <Dashboard title="Estadísticas" items={items}>
+      <h1>Resumen de Productividad</h1>
+    </Dashboard>
+  );
+};
+
+export default Summary;

--- a/frontend/src/components/ui/dashboard/Dashboard.tsx
+++ b/frontend/src/components/ui/dashboard/Dashboard.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { DashboardMenu } from "./DashboardMenu";
+import { DashboardMenuItem } from "./DashboardMenuItem";
+
+type DashboardItem = {
+  value: string;
+  href: string;
+  selected: boolean;
+};
+
+type Props = {
+  title: string;
+  items: DashboardItem[];
+} & React.ComponentProps<"div">;
+
+export const Dashboard = ({ title, items, children }: Props) => {
+  return (
+    <div
+      className="w-full h-full
+                 pt-[126px]
+                 pl-[152px]"
+    >
+      <h1
+        className="text-[#09090B]
+                   font-roboto
+                   font-[700]
+                   text-[36px]"
+      >
+        {title}
+      </h1>
+      <DashboardMenu>
+        {items.map((item) => (
+          <div key={item.href}>
+            <DashboardMenuItem value={item.value} href={item.href} />
+
+            {item.selected && children}
+          </div>
+        ))}
+      </DashboardMenu>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/dashboard/DashboardMenu.tsx
+++ b/frontend/src/components/ui/dashboard/DashboardMenu.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+type Props = React.ComponentProps<"div">;
+
+export const DashboardMenu = ({ children }: Props) => {
+  return (
+    <aside
+      className="w-full
+                 h-full
+                 mt-[39px]"
+    >
+      {children}
+    </aside>
+  );
+};

--- a/frontend/src/components/ui/dashboard/DashboardMenuItem.tsx
+++ b/frontend/src/components/ui/dashboard/DashboardMenuItem.tsx
@@ -1,0 +1,42 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { memo } from "react";
+
+type Props = {
+  value: string;
+  href: string;
+};
+
+export const DashboardMenuItem = memo(({ value, href }: Props) => {
+  return (
+    <div
+      className="w-[255px]
+                 py-[6px]
+                 px-[6px]
+                 flex
+                 items-center
+                 min-h-[36px]
+                 gap-x-2.5"
+    >
+      <Link
+        href={href}
+        className="flex
+                   items-center
+                   text-[14px]
+                   font-[400]
+                   font-inter
+                   w-full
+                   gap-x-2.5"
+      >
+        <span>{value}</span>
+        <div
+          className="h-4 w-4
+                     flex
+                     items-center"
+        >
+          <ChevronRight />
+        </div>
+      </Link>
+    </div>
+  );
+});

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,62 +1,68 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-    darkMode: ["class"],
-    content: [
+  darkMode: ["class"],
+  content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		}
-  	}
+    extend: {
+      fontFamily: {
+        inter: ["var(--font-inter)", "sans-serif"],
+        roboto: ["var(--font-roboto)", "sans-serif"],
+        geist: ["var(--font-geist-sans)", "sans-serif"],
+        mono: ["var(--font-geist-mono)", "monospace"],
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          "1": "hsl(var(--chart-1))",
+          "2": "hsl(var(--chart-2))",
+          "3": "hsl(var(--chart-3))",
+          "4": "hsl(var(--chart-4))",
+          "5": "hsl(var(--chart-5))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
![dashboard](https://github.com/user-attachments/assets/ce8156fb-e4b8-4a69-958a-99a269716f1d)


Se agregó el componente Dashboard para ser reutilizado en las páginas de estadísticas, perfil del usuario y Configuraciones.

Ver en las páginas de Estadísticas donde está montado para entender mejor como poder reutilizarlo.





